### PR TITLE
Sanitize mock API paths

### DIFF
--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -56,4 +56,18 @@ describe("AponiAPI", () => {
       body: JSON.stringify({ foo: "bar" }),
     });
   });
+
+  it("normalizes mock paths to stay within the mock directory", async () => {
+    const mockResponse = { ok: true, json: () => Promise.resolve({}) };
+    global.fetch.mockResolvedValue(mockResponse);
+
+    await apiGet("reports/../status");
+
+    expect(global.fetch).toHaveBeenCalledWith("./mock/status.json", { cache: "no-cache" });
+  });
+
+  it("rejects attempts to traverse outside the mock directory", async () => {
+    await expect(apiGet("../config")).rejects.toThrow("Invalid mock path traversal");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
 });

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -11,13 +11,36 @@
     return normalized ? `/${normalized}` : "/";
   }
 
+  function sanitizeMockPath(path) {
+    const parts = (path || "").toString().split("/").filter(Boolean);
+    const safeParts = [];
+
+    for (const part of parts) {
+      if (part === ".") {
+        continue;
+      }
+
+      if (part === "..") {
+        if (!safeParts.length) {
+          throw new Error(`Invalid mock path traversal: ${path}`);
+        }
+        safeParts.pop();
+        continue;
+      }
+
+      safeParts.push(part);
+    }
+
+    return safeParts.join("/");
+  }
+
   function buildLiveUrl(path) {
     const base = (global.APONI_API_BASE || "").replace(/\/$/, "");
     return `${base}${normalizePath(path)}`;
   }
 
   function buildMockUrl(path) {
-    const normalized = normalizePath(path).replace(/^\//, "");
+    const normalized = sanitizeMockPath(path);
     return `./mock/${normalized || "index"}.json`;
   }
 


### PR DESCRIPTION
## Summary
- sanitize mock API request paths to stay within the mock directory and reject traversal attempts
- normalize mock URL construction to collapse relative segments safely
- add tests covering path normalization and blocking traversal inputs

## Testing
- npm test -- --runInBand *(fails: setImmediate is not defined in aponi_dashboard_tree tests)*
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a9064d630832b9bb73e2df3763bcd)